### PR TITLE
Proposal: use ruff instead of black as suggested python formatter

### DIFF
--- a/star/python.star
+++ b/star/python.star
@@ -38,10 +38,10 @@ def python_add_uv(name, uv_version, ruff_version, python_version, packages = [])
     )
 
     checkout_update_asset(
-        "{}_black_formatter_vs_code".format(name),
+        "{}_ruff_formatter_vs_code".format(name),
         destination = ".vscode/extensions.json",
         value = {
-            "recommendations": ["ms-python.python", "ms-python.black-formatter"],
+            "recommendations": ["ms-python.python", "charliermarsh.ruff"],
         },
     )
 


### PR DESCRIPTION
Ruff formatter is much faster than Black and is Black-compatible. It's also written in Rust.
https://astral.sh/blog/the-ruff-formatter